### PR TITLE
chore: use build-packages

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,9 +11,7 @@ parts:
   charm:
     build-packages:
       - cargo
+      - libffi-dev
+      - libssl-dev
+      - pkg-config
       - rustc
-    charm-binary-python-packages:
-      - cryptography
-      - jsonschema
-      - pip
-      - setuptools


### PR DESCRIPTION
# Description

Use build-packages and install Python packages using requirements file instead of leveraging pre-built binaries. This avoids surprises and inconsistencies from the dev environment.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library