### PR TITLE
fix: remove unnecessary callback when relation broken

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -68,8 +68,6 @@ class AUSFOperatorCharm(CharmBase):
         self.framework.observe(self.on.ausf_pebble_ready, self._configure_ausf)
         self.framework.observe(self.on.fiveg_nrf_relation_joined, self._configure_ausf)
         self.framework.observe(self._nrf_requires.on.nrf_available, self._configure_ausf)
-        self.framework.observe(self._nrf_requires.on.nrf_broken, self._configure_ausf)
-
         self.framework.observe(self.on.certificates_relation_joined, self._configure_ausf)
         self.framework.observe(
             self.on.certificates_relation_broken, self._on_certificates_relation_broken


### PR DESCRIPTION
# Description

In case of nrf broken event, the call to _configure_ausf returns immediately due to the missing relation and does not perform any configuration.
It can be removed.
Blocked status is automatically set by the collect unit status event.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library