### PR TITLE
fix: Run _configure_ausf on update_status

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -66,6 +66,7 @@ class AUSFOperatorCharm(CharmBase):
         self._certificates = TLSCertificatesRequiresV3(self, "certificates")
         self._logging = LogForwarder(charm=self, relation_name=LOGGING_RELATION_NAME)
         self.framework.observe(self.on.ausf_pebble_ready, self._configure_ausf)
+        self.framework.observe(self.on.update_status, self._configure_ausf)
         self.framework.observe(self.on.fiveg_nrf_relation_joined, self._configure_ausf)
         self.framework.observe(self._nrf_requires.on.nrf_available, self._configure_ausf)
         self.framework.observe(self.on.certificates_relation_joined, self._configure_ausf)


### PR DESCRIPTION
# Description

While testing the upgrade scenario, the AUSF service couldn't be started on the first attempt. With the current implementation of the charm, starting the service will not be reattempted unless config changes.
This PR makes sure that the `_configure_ausf` method is run on every `update_status` event. 

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library