### PR TITLE
fix: Only replan if there are actual changes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -433,12 +433,17 @@ class AUSFOperatorCharm(CharmBase):
         Args:
             restart (bool): Whether to restart the Pebble service. Defaults to False.
         """
-        self._container.add_layer(self._container_name, self._pebble_layer, combine=True)
+        plan = self._container.get_plan()
+        if plan.services != self._pebble_layer.services:
+            self._container.add_layer(
+                self._container_name, self._pebble_layer, combine=True
+            )
+            self._container.replan()
+            logger.info("New layer added: %s", self._pebble_layer)
         if restart:
             self._container.restart(self._service_name)
             logger.info("Restarted container %s", self._service_name)
             return
-        self._container.replan()
 
     def _relation_created(self, relation_name: str) -> bool:
         """Return True if the relation is created, False otherwise.


### PR DESCRIPTION
# Description

Rather than replanning with every status update, this change performs a comparison to ensure a replan is needed.

# Checklist:

- [X] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [X] I validated that new and existing unit tests pass locally with my changes
- N/A Any dependent changes have been merged and published in downstream modules
- N/A I have bumped the version of the library