### PR TITLE
chore: Reusing _deploy_nrf in _deploy_and_integrate_nrf_and_mongodb

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -41,11 +41,7 @@ async def _deploy_mongodb(ops_test: OpsTest):
 async def _deploy_and_integrate_nrf_and_mongodb(ops_test: OpsTest):
     assert ops_test.model
     await _deploy_mongodb(ops_test)
-    await ops_test.model.deploy(
-        NRF_APPLICATION_NAME,
-        application_name=NRF_APPLICATION_NAME,
-        channel=NRF_APPLICATION_CHANNEL,
-    )
+    await _deploy_nrf(ops_test)
     await ops_test.model.integrate(relation1=DB_APPLICATION_NAME, relation2=NRF_APPLICATION_NAME)
     await ops_test.model.integrate(relation1=NRF_APPLICATION_NAME, relation2=TLS_PROVIDER_NAME)
 


### PR DESCRIPTION
# Description

Reusing `_deploy_nrf` in `_deploy_and_integrate_nrf_and_mongodb`

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library