### PR TITLE
chore: use pytest for unit tests

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -172,12 +172,12 @@ class AUSFOperatorCharm(CharmBase):
 
     def _configure_ausf(
         self,
-        event: EventBase,
+        _: EventBase,
     ) -> None:
         """Configure AUSF configuration file and pebble service.
 
         Args:
-            event (EventBase): Juju event
+            _ (EventBase): Juju event
         """
         if not self.ready_to_configure():
             logger.info("The preconditions for the configuration are not met yet.")
@@ -369,8 +369,8 @@ class AUSFOperatorCharm(CharmBase):
         self._container.push(path=f"{CERTS_DIR_PATH}/{CSR_NAME}", source=csr.decode().strip())
         logger.info("Pushed CSR to workload")
 
+    @staticmethod
     def _render_config_file(
-        self,
         *,
         ausf_group_id: str,
         ausf_ip: str,

--- a/tests/unit/test_charm_relations.py
+++ b/tests/unit/test_charm_relations.py
@@ -1,154 +1,59 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import unittest
 from pathlib import Path
-from typing import Tuple
+from typing import Generator, Tuple
 from unittest.mock import Mock, patch
 
+import pytest
 from charm import AUSFOperatorCharm
 from ops import ActiveStatus, testing
 
 from lib.charms.tls_certificates_interface.v3.tls_certificates import ProviderCertificate
 
-TEST_NRF_URL = "https://nrf-example.com:1234"
+CONTAINER_NAME = "ausf"
 TEST_POD_IP = b"1.2.3.4"
+TEST_PRIVATE_KEY = b"whatever private key"
+TEST_CSR = b"whatever csr"
+TEST_CERTIFICATE = "whatever certificate"
+NAMESPACE = "whatever"
+TEST_NRF_URL = "https://nrf-example.com:1234"
 
 
-class TestCharmRelations(unittest.TestCase):
-    def setUp(self):
-        self.namespace = "whatever"
+class TestCharmRelations:
+    patcher_check_output = patch("charm.check_output")
+    patcher_generate_csr = patch("charm.generate_csr")
+    patcher_get_assigned_certificates = patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates")  # noqa: E501
+    patcher_request_certificate_creation = patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation")  # noqa: E501
+
+    @pytest.fixture()
+    def setup(self):
+        self.mock_check_output = TestCharmRelations.patcher_check_output.start()
+        self.mock_generate_csr = TestCharmRelations.patcher_generate_csr.start()
+        self.mock_get_assigned_certificates = TestCharmRelations.patcher_get_assigned_certificates.start()  # noqa: E501
+        self.mock_request_certificate_creation = TestCharmRelations.patcher_request_certificate_creation.start()  # noqa: E501
+
+    @staticmethod
+    def teardown() -> None:
+        patch.stopall()
+
+    @pytest.fixture(autouse=True)
+    def create_harness(self, setup, request):
         self.harness = testing.Harness(AUSFOperatorCharm)
-        self.harness.set_model_name(name=self.namespace)
-        self.addCleanup(self.harness.cleanup)
+        self.harness.set_model_name(name=NAMESPACE)
         self.harness.set_leader(is_leader=True)
         self.harness.begin()
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.teardown)
 
-    @patch("charm.check_output")
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    def test_given_charm_is_in_active_state_when_certificates_relation_broken_then_certificate_csr_and_private_key_are_removed(  # noqa: E501
-        self, patched_get_assigned_certificates, patched_check_output
-    ):
-        test_private_key = b"whatever private key"
-        test_csr = b"whatever csr"
-        test_certificate = "whatever certificate"
-        self.harness.set_can_connect(container="ausf", val=True)
-        certificates_relation_id, _ = self._create_charm_relations_and_relation_data()
+    @pytest.fixture()
+    def add_storage(self):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        patched_check_output.return_value = TEST_POD_IP
-        root = self.harness.get_filesystem_root("ausf")
-        (root / "support/TLS/ausf.csr").write_text(test_csr.decode())
-        (root / "support/TLS/ausf.key").write_text(test_private_key.decode())
-        (root / "support/TLS/ausf.pem").write_text(test_certificate)
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = test_certificate
-        provider_certificate.csr = test_csr.decode()
-        patched_get_assigned_certificates.return_value = [
-            provider_certificate,
-        ]
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-        self.harness.charm._on_certificates_relation_broken(event=Mock)
-
-        with self.assertRaises(FileNotFoundError):
-            (root / "support/TLS/ausf.key").read_text()
-        with self.assertRaises(FileNotFoundError):
-            (root / "support/TLS/ausf.pem").read_text()
-        with self.assertRaises(FileNotFoundError):
-            (root / "support/TLS/ausf.csr").read_text()
-
-    @patch("charm.check_output")
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation",  # noqa: E501
-    )
-    def test_given_charm_is_in_active_state_when_certificate_expiring_then_new_certificate_is_requested(  # noqa: E501
-        self,
-        patched_request_certificate_creation,
-        patched_generate_csr,
-        patched_get_assigned_certificates,
-        patched_check_output,
-    ):
-        test_csr = b"whatever csr"
-        test_certificate = "whatever certificate"
-        self.harness.set_can_connect(container="ausf", val=True)
-        self._create_charm_relations_and_relation_data()
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-        patched_check_output.return_value = TEST_POD_IP
-        patched_generate_csr.return_value = test_csr
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = test_certificate
-        provider_certificate.csr = test_csr.decode()
-        patched_get_assigned_certificates.return_value = [
-            provider_certificate,
-        ]
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
-
-        event = Mock()
-        event.certificate = test_certificate
-        self.harness.charm._on_certificate_expiring(event=event)
-
-        patched_request_certificate_creation.assert_called_with(
-            certificate_signing_request=test_csr
-        )
-
-    @patch("charm.check_output")
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    def test_given_charm_is_in_active_state_when_nrf_available_then_ausf_config_is_updated(
-        self, patched_get_assigned_certificates, patched_check_output
-    ):
-        test_private_key = b"whatever private key"
-        test_csr = b"whatever csr"
-        test_certificate = "whatever certificate"
-        self.harness.set_can_connect(container="ausf", val=True)
-        _, fiveg_nrf_relation_id = self._create_charm_relations_and_relation_data()
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-        patched_check_output.return_value = TEST_POD_IP
-        root = self.harness.get_filesystem_root("ausf")
-        (root / "support/TLS/ausf.csr").write_text(test_csr.decode())
-        (root / "support/TLS/ausf.key").write_text(test_private_key.decode())
-        (root / "support/TLS/ausf.pem").write_text(test_certificate)
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = test_certificate
-        provider_certificate.csr = test_csr.decode()
-        patched_get_assigned_certificates.return_value = [
-            provider_certificate,
-        ]
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
-
-        new_nrf_url = "https://new-nrf-url.com:1234"
-        self.harness.update_relation_data(
-            relation_id=fiveg_nrf_relation_id,
-            app_or_unit="whatever-nrf",
-            key_values={"url": new_nrf_url},
-        )
-
-        expected_config_file_path = Path(__file__).parent / "expected_config" / "config.conf"
-        with open(expected_config_file_path, "r") as expected_config_file:
-            expected_config = expected_config_file.read()
-
-            self.assertEqual(
-                (root / "free5gc/config/ausfcfg.conf").read_text(),
-                expected_config.replace(TEST_NRF_URL, new_nrf_url),
-            )
-
-    def _create_charm_relations_and_relation_data(self) -> Tuple[int, int]:
+    @pytest.fixture()
+    def create_charm_relations_and_relation_data(self) -> Generator[Tuple[int, int], None, None]:
         certificates_relation_id = self.harness.add_relation(
             relation_name="certificates", remote_app="whatever-certs"
         )
@@ -163,4 +68,88 @@ class TestCharmRelations(unittest.TestCase):
             app_or_unit="whatever-nrf",
             key_values={"url": TEST_NRF_URL},
         )
-        return certificates_relation_id, fiveg_nrf_relation_id
+        yield certificates_relation_id, fiveg_nrf_relation_id
+
+    def test_given_charm_is_in_active_state_when_certificates_relation_broken_then_certificate_csr_and_private_key_are_removed(  # noqa: E501
+        self, create_charm_relations_and_relation_data, add_storage
+    ):
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+        self.mock_check_output.return_value = TEST_POD_IP
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
+        (root / "support/TLS/ausf.csr").write_text(TEST_CSR.decode())
+        (root / "support/TLS/ausf.key").write_text(TEST_PRIVATE_KEY.decode())
+        (root / "support/TLS/ausf.pem").write_text(TEST_CERTIFICATE)
+        provider_certificate = Mock(ProviderCertificate)
+        provider_certificate.certificate = TEST_CERTIFICATE
+        provider_certificate.csr = TEST_CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
+            provider_certificate,
+        ]
+        self.harness.charm.on.update_status.emit()
+        self.harness.evaluate_status()
+        assert self.harness.model.unit.status == ActiveStatus()
+
+        self.harness.charm._on_certificates_relation_broken(event=Mock)
+
+        with pytest.raises(FileNotFoundError):
+            (root / "support/TLS/ausf.key").read_text()
+        with pytest.raises(FileNotFoundError):
+            (root / "support/TLS/ausf.pem").read_text()
+        with pytest.raises(FileNotFoundError):
+            (root / "support/TLS/ausf.csr").read_text()
+
+    def test_given_charm_is_in_active_state_when_certificate_expiring_then_new_certificate_is_requested(  # noqa E501
+        self, create_charm_relations_and_relation_data, add_storage
+    ):
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+        self.mock_check_output.return_value = TEST_POD_IP
+        self.mock_generate_csr.return_value = TEST_CSR
+        provider_certificate = Mock(ProviderCertificate)
+        provider_certificate.certificate = TEST_CERTIFICATE
+        provider_certificate.csr = TEST_CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
+            provider_certificate,
+        ]
+        self.harness.charm.on.update_status.emit()
+        self.harness.evaluate_status()
+        assert self.harness.model.unit.status == ActiveStatus()
+
+        event = Mock()
+        event.certificate = TEST_CERTIFICATE
+        self.harness.charm._on_certificate_expiring(event=event)
+
+        self.mock_request_certificate_creation.assert_called_with(
+            certificate_signing_request=TEST_CSR
+        )
+
+    def test_given_charm_is_in_active_state_when_nrf_available_then_ausf_config_is_updated(
+        self, create_charm_relations_and_relation_data, add_storage
+    ):
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+        self.mock_check_output.return_value = TEST_POD_IP
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
+        (root / "support/TLS/ausf.csr").write_text(TEST_CSR.decode())
+        (root / "support/TLS/ausf.key").write_text(TEST_PRIVATE_KEY.decode())
+        (root / "support/TLS/ausf.pem").write_text(TEST_CERTIFICATE)
+        provider_certificate = Mock(ProviderCertificate)
+        provider_certificate.certificate = TEST_CERTIFICATE
+        provider_certificate.csr = TEST_CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
+            provider_certificate,
+        ]
+        self.harness.charm.on.update_status.emit()
+        self.harness.evaluate_status()
+        assert self.harness.model.unit.status == ActiveStatus()
+
+        new_nrf_url = "https://new-nrf-url.com:1234"
+        self.harness.update_relation_data(
+            relation_id=create_charm_relations_and_relation_data[1],
+            app_or_unit="whatever-nrf",
+            key_values={"url": new_nrf_url},
+        )
+
+        expected_config_file_path = Path(__file__).parent / "expected_config" / "config.conf"
+        with open(expected_config_file_path, "r") as expected_config_file:
+            expected_config = expected_config_file.read()
+
+            assert (root / "free5gc/config/ausfcfg.conf").read_text() == expected_config.replace(TEST_NRF_URL, new_nrf_url)  # noqa E501

--- a/tests/unit/test_charm_status.py
+++ b/tests/unit/test_charm_status.py
@@ -20,13 +20,13 @@ NAMESPACE = "whatever"
 class TestCharmStatus:
     patcher_check_output = patch("charm.check_output")
     patcher_get_assigned_certificates = patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates")  # noqa: E501
-    patcher_get = patch("ops.model.Container.get_service")
+    patcher_get_service = patch("ops.model.Container.get_service")
 
     @pytest.fixture()
     def setup(self):
         self.mock_check_output = TestCharmStatus.patcher_check_output.start()
         self.mock_get_assigned_certificates = TestCharmStatus.patcher_get_assigned_certificates.start()  # noqa: E501
-        self.mock_get = TestCharmStatus.patcher_get.start()
+        self.mock_get_service = TestCharmStatus.patcher_get_service.start()
 
     @staticmethod
     def teardown() -> None:
@@ -170,7 +170,7 @@ class TestCharmStatus:
         self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
-        self.mock_get.side_effect = ModelError()
+        self.mock_get_service.side_effect = ModelError()
 
         self.harness.charm.on.update_status.emit()
         self.harness.evaluate_status()

--- a/tests/unit/test_charm_status.py
+++ b/tests/unit/test_charm_status.py
@@ -1,217 +1,54 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import unittest
+from typing import Generator
 from unittest.mock import Mock, patch
 
+import pytest
 from charm import AUSFOperatorCharm
 from ops import ActiveStatus, BlockedStatus, ModelError, WaitingStatus, testing
 
 from lib.charms.tls_certificates_interface.v3.tls_certificates import ProviderCertificate
 
+CONTAINER_NAME = "ausf"
 TEST_POD_IP = b"1.2.3.4"
+TEST_CSR = b"whatever csr"
+TEST_CERTIFICATE = "whatever certificate"
+NAMESPACE = "whatever"
 
 
-class TestCharmStatus(unittest.TestCase):
-    def setUp(self):
-        self.namespace = "whatever"
+class TestCharmStatus:
+    patcher_check_output = patch("charm.check_output")
+    patcher_get_assigned_certificates = patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates")  # noqa: E501
+    patcher_get = patch("ops.model.Container.get_service")
+
+    @pytest.fixture()
+    def setup(self):
+        self.mock_check_output = TestCharmStatus.patcher_check_output.start()
+        self.mock_get_assigned_certificates = TestCharmStatus.patcher_get_assigned_certificates.start()  # noqa: E501
+        self.mock_get = TestCharmStatus.patcher_get.start()
+
+    @staticmethod
+    def teardown() -> None:
+        patch.stopall()
+
+    @pytest.fixture(autouse=True)
+    def create_harness(self, setup, request):
         self.harness = testing.Harness(AUSFOperatorCharm)
-        self.harness.set_model_name(name=self.namespace)
-        self.addCleanup(self.harness.cleanup)
+        self.harness.set_model_name(name=NAMESPACE)
         self.harness.set_leader(is_leader=True)
         self.harness.begin()
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.teardown)
 
-    def test_given_unit_is_not_leader_when_update_status_then_status_is_blocked(self):
-        self.harness.set_leader(is_leader=False)
-
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Scaling is not implemented for this charm"),
-        )
-
-    def test_given_unit_is_leader_but_container_is_not_ready_when_update_status_then_status_is_waiting(  # noqa: E501
-        self,
-    ):
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for container to start")
-        )
-
-    def test_given_unit_is_leader_and_container_is_ready_but_relations_are_not_created_when_update_status_then_status_is_blocked(  # noqa: E501
-        self,
-    ):
-        self.harness.set_can_connect(container="ausf", val=True)
-
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-
-        self.assertEqual(
-            self.harness.model.unit.status, BlockedStatus("Waiting for fiveg_nrf relation")
-        )
-
-    def test_given_unit_is_leader_and_container_is_ready_but_fiveg_nrf_relation_is_not_created_when_update_status_then_status_is_blocked(  # noqa: E501
-        self,
-    ):
-        self.harness.set_can_connect(container="ausf", val=True)
-        self.harness.add_relation(relation_name="certificates", remote_app="whatever")
-
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-
-        self.assertEqual(
-            self.harness.model.unit.status, BlockedStatus("Waiting for fiveg_nrf relation")
-        )
-
-    def test_given_unit_is_leader_and_container_is_ready_but_certificates_relation_is_not_created_when_update_status_then_status_is_blocked(  # noqa: E501
-        self,
-    ):
-        self.harness.set_can_connect(container="ausf", val=True)
-        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="whatever")
-
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-
-        self.assertEqual(
-            self.harness.model.unit.status, BlockedStatus("Waiting for certificates relation")
-        )
-
-    def test_given_unit_is_leader_and_container_is_ready_and_relations_are_created_but_nrf_data_is_not_available_when_update_status_then_status_is_waiting(  # noqa: E501
-        self,
-    ):
-        self.harness.set_can_connect(container="ausf", val=True)
-        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="whatever")
-        self.harness.add_relation(relation_name="certificates", remote_app="whatever")
-
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for NRF data to be available")
-        )
-
-    def test_given_unit_is_leader_and_container_is_ready_and_relations_are_created_and_nrf_data_is_available_but_storage_is_not_ready_when_update_status_then_status_is_waiting(  # noqa: E501
-        self,
-    ):
-        self.harness.set_can_connect(container="ausf", val=True)
-        self.harness.add_relation(relation_name="certificates", remote_app="whatever-certs")
-        self._create_nrf_relation_and_set_nrf_url()
-
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for storage to be attached")
-        )
-
-    @patch("charm.check_output")
-    def test_given_unit_is_leader_and_container_is_ready_and_relations_are_created_and_nrf_data_is_available_and_storage_is_ready_but_pod_ip_is_not_available_when_update_status_then_status_is_waiting(  # noqa: E501
-        self, patched_check_output
-    ):
-        self.harness.add_storage(storage_name="config", attach=True)
-        patched_check_output.return_value = b""
-        self.harness.set_can_connect(container="ausf", val=True)
-        self.harness.add_relation(relation_name="certificates", remote_app="whatever-certs")
-        self._create_nrf_relation_and_set_nrf_url()
-
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for pod IP address to be available"),
-        )
-
-    @patch("charm.check_output")
-    def test_given_unit_is_leader_and_container_is_ready_and_relations_are_created_and_nrf_data_is_available_and_storage_is_ready_and_pod_ip_is_available_but_csr_is_not_stored_when_update_status_then_status_is_waiting(  # noqa: E501
-        self, patched_check_output
-    ):
+    @pytest.fixture()
+    def add_storage(self):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        patched_check_output.return_value = TEST_POD_IP
-        self.harness.set_can_connect(container="ausf", val=True)
-        self.harness.add_relation(relation_name="certificates", remote_app="whatever-certs")
-        self._create_nrf_relation_and_set_nrf_url()
 
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for certificates to be stored"),
-        )
-
-    @patch("charm.check_output")
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("ops.model.Container.get_service")
-    def test_given_unit_is_leader_and_container_is_ready_and_relations_are_created_and_nrf_data_is_available_and_storage_is_ready_and_pod_ip_is_available_and_csr_is_stored_but_ausf_service_is_not_running_when_update_status_then_status_is_waiting(  # noqa: E501
-        self, patched_get_service, patched_get_assigned_certificates, patched_check_output
-    ):
-        test_csr = b"whatever csr"
-        test_certificate = "whatever certificate"
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-        patched_check_output.return_value = TEST_POD_IP
-        self.harness.set_can_connect(container="ausf", val=True)
-        self.harness.add_relation(relation_name="certificates", remote_app="whatever-certs")
-        self._create_nrf_relation_and_set_nrf_url()
-        root = self.harness.get_filesystem_root("ausf")
-        (root / "support/TLS/ausf.csr").write_text(test_csr.decode())
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = test_certificate
-        provider_certificate.csr = test_csr.decode()
-        patched_get_assigned_certificates.return_value = [
-            provider_certificate,
-        ]
-        patched_get_service.side_effect = ModelError()
-
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for AUSF service to start"),
-        )
-
-    @patch("charm.check_output")
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    def test_given_unit_is_configured_correctly_when_update_status_then_status_is_active(
-        self, patched_get_assigned_certificates, patched_check_output
-    ):
-        test_csr = b"whatever csr"
-        test_certificate = "whatever certificate"
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-        patched_check_output.return_value = TEST_POD_IP
-        self.harness.set_can_connect(container="ausf", val=True)
-        self.harness.add_relation(relation_name="certificates", remote_app="whatever-certs")
-        self._create_nrf_relation_and_set_nrf_url()
-        root = self.harness.get_filesystem_root("ausf")
-        (root / "support/TLS/ausf.csr").write_text(test_csr.decode())
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = test_certificate
-        provider_certificate.csr = test_csr.decode()
-        patched_get_assigned_certificates.return_value = [
-            provider_certificate,
-        ]
-
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
-
-    def _create_nrf_relation_and_set_nrf_url(self):
-        fiveg_nrf_relation_id = self.harness.add_relation(
-            relation_name="fiveg_nrf", remote_app="whatever-nrf"
-        )
+    @pytest.fixture()
+    def create_nrf_relation_and_set_nrf_url(self, fiveg_nrf_relation_id):
         self.harness.add_relation_unit(
             relation_id=fiveg_nrf_relation_id, remote_unit_name="whatever-nrf/0"
         )
@@ -220,3 +57,141 @@ class TestCharmStatus(unittest.TestCase):
             app_or_unit="whatever-nrf",
             key_values={"url": "https://nrf-example.com:1234"},
         )
+
+    @pytest.fixture()
+    def fiveg_nrf_relation_id(self) -> Generator[int, None, None]:
+        yield self.harness.add_relation(
+            relation_name="fiveg_nrf",
+            remote_app="whatever-nrf",
+        )
+
+    @pytest.fixture()
+    def certificates_relation_id(self) -> Generator[int, None, None]:
+        yield self.harness.add_relation(
+            relation_name="certificates",
+            remote_app="whatever",
+        )
+
+    def test_given_unit_is_not_leader_when_update_status_then_status_is_blocked(self):
+        self.harness.set_leader(is_leader=False)
+
+        self.harness.charm.on.update_status.emit()
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == BlockedStatus("Scaling is not implemented for this charm")  # noqa: E501
+
+    def test_given_unit_is_leader_but_container_is_not_ready_when_update_status_then_status_is_waiting(self):  # noqa: E501
+        self.harness.charm.on.update_status.emit()
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for container to start")
+
+    def test_given_unit_is_leader_and_container_is_ready_but_relations_are_not_created_when_update_status_then_status_is_blocked(self):  # noqa: E501
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+
+        self.harness.charm.on.update_status.emit()
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation")
+
+    def test_given_unit_is_leader_and_container_is_ready_but_fiveg_nrf_relation_is_not_created_when_update_status_then_status_is_blocked(  # noqa: E501
+        self, certificates_relation_id
+    ):
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+
+        self.harness.charm.on.update_status.emit()
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation")
+
+    def test_given_unit_is_leader_and_container_is_ready_but_certificates_relation_is_not_created_when_update_status_then_status_is_blocked(  # noqa: E501
+        self, fiveg_nrf_relation_id
+    ):
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+
+        self.harness.charm.on.update_status.emit()
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for certificates relation")
+
+    def test_given_unit_is_leader_and_container_is_ready_and_relations_are_created_but_nrf_data_is_not_available_when_update_status_then_status_is_waiting(  # noqa: E501
+        self, certificates_relation_id, fiveg_nrf_relation_id
+    ):
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+
+        self.harness.charm.on.update_status.emit()
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for NRF data to be available")  # noqa: E501
+
+    def test_given_unit_is_leader_and_container_is_ready_and_relations_are_created_and_nrf_data_is_available_but_storage_is_not_ready_when_update_status_then_status_is_waiting(  # noqa: E501
+        self, create_nrf_relation_and_set_nrf_url, certificates_relation_id
+    ):
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+
+        self.harness.charm.on.update_status.emit()
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for storage to be attached")  # noqa: E501
+
+    def test_given_unit_is_leader_and_container_is_ready_and_relations_are_created_and_nrf_data_is_available_and_storage_is_ready_but_pod_ip_is_not_available_when_update_status_then_status_is_waiting(  # noqa: E501
+        self, create_nrf_relation_and_set_nrf_url, certificates_relation_id
+    ):
+        self.harness.add_storage(storage_name="config", attach=True)
+        self.mock_check_output.return_value = b""
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+
+        self.harness.charm.on.update_status.emit()
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for pod IP address to be available")  # noqa: E501
+
+    def test_given_unit_is_leader_and_container_is_ready_and_relations_are_created_and_nrf_data_is_available_and_storage_is_ready_and_pod_ip_is_available_but_csr_is_not_stored_when_update_status_then_status_is_waiting(  # noqa: E501
+        self, create_nrf_relation_and_set_nrf_url, certificates_relation_id, add_storage
+    ):
+        self.mock_check_output.return_value = TEST_POD_IP
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+
+        self.harness.charm.on.update_status.emit()
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for certificates to be stored")  # noqa: E501
+
+    def test_given_unit_is_leader_and_container_is_ready_and_relations_are_created_and_nrf_data_is_available_and_storage_is_ready_and_pod_ip_is_available_and_csr_is_stored_but_ausf_service_is_not_running_when_update_status_then_status_is_waiting(  # noqa: E501
+        self, create_nrf_relation_and_set_nrf_url, certificates_relation_id, add_storage
+    ):
+        self.mock_check_output.return_value = TEST_POD_IP
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
+        (root / "support/TLS/ausf.csr").write_text(TEST_CSR.decode())
+        provider_certificate = Mock(ProviderCertificate)
+        provider_certificate.certificate = TEST_CERTIFICATE
+        provider_certificate.csr = TEST_CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
+            provider_certificate,
+        ]
+        self.mock_get.side_effect = ModelError()
+
+        self.harness.charm.on.update_status.emit()
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for AUSF service to start")
+
+    def test_given_unit_is_configured_correctly_when_update_status_then_status_is_active(
+        self, create_nrf_relation_and_set_nrf_url, certificates_relation_id, add_storage
+    ):
+        self.mock_check_output.return_value = TEST_POD_IP
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+        root = self.harness.get_filesystem_root(CONTAINER_NAME)
+        (root / "support/TLS/ausf.csr").write_text(TEST_CSR.decode())
+        provider_certificate = Mock(ProviderCertificate)
+        provider_certificate.certificate = TEST_CERTIFICATE
+        provider_certificate.csr = TEST_CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
+            provider_certificate,
+        ]
+
+        self.harness.charm.on.update_status.emit()
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == ActiveStatus()


### PR DESCRIPTION
# Description

This PR aims to remove `unittest` framework in favor of `pytest`, as described [here](https://juju.is/docs/sdk/write-a-unit-test-for-a-charm).
Main changes:
* Use fixtures to configure harness and patches
* Use fixtures to create `fiveg_nrf`, `certificates` relations
* Use fixture to add `certs` and `config` storage

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [X] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library