### PR TITLE
chore: adapt test name to reflect tls lib v4

### DIFF
--- a/tests/unit/test_charm_certificates_relation_broken.py
+++ b/tests/unit/test_charm_certificates_relation_broken.py
@@ -17,7 +17,7 @@ TEST_NRF_URL = "https://nrf-example.com:1234"
 
 
 class TestCharmCertificateRelationBroken(AUSFUnitTestFixtures):
-    def test_given_charm_is_in_active_state_when_certificates_relation_broken_then_certificate_csr_and_private_key_are_removed(  # noqa: E501
+    def test_given_charm_is_in_active_state_when_certificates_relation_broken_then_certificate_and_private_key_are_removed(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
# Description

Now that we use the tls library v4 we don't manage csr's anymore. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library