### PR TITLE
fix: sdcore_config interface tests

### DIFF
--- a/lib/charms/sdcore_nms_k8s/v0/sdcore_config.py
+++ b/lib/charms/sdcore_nms_k8s/v0/sdcore_config.py
@@ -149,7 +149,7 @@ class SdcoreConfigProviderAppData(BaseModel):
 
 
 class ProviderSchema(DataBagSchema):
-    """The schema for the provider side of the sdcore-config interface."""
+    """The schema for the provider side of the sdcore_config interface."""
     app: SdcoreConfigProviderAppData
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -4,3 +4,4 @@ pytest-interface-tester
 jsonschema
 cryptography
 cosl
+jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,12 +18,18 @@ cosl==0.0.23
     # via -r requirements.in
 cryptography==43.0.0
     # via -r requirements.in
+exceptiongroup==1.2.2
+    # via pytest
 iniconfig==2.0.0
     # via pytest
+jinja2==3.1.4
+    # via -r requirements.in
 jsonschema==4.23.0
     # via -r requirements.in
 jsonschema-specifications==2023.12.1
     # via jsonschema
+markupsafe==2.1.5
+    # via jinja2
 ops==2.15.0
     # via
     #   -r requirements.in
@@ -63,6 +69,8 @@ rpds-py==0.18.0
     #   referencing
 tenacity==9.0.0
     # via cosl
+tomli==2.0.1
+    # via pytest
 typer==0.7.0
     # via pytest-interface-tester
 typing-extensions==4.9.0

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -1,0 +1,41 @@
+import tempfile
+
+import pytest
+import scenario
+from interface_tester import InterfaceTester
+from ops.pebble import Layer, ServiceStatus
+
+from charm import AUSFOperatorCharm
+
+
+@pytest.fixture
+def interface_tester(interface_tester: InterfaceTester):
+    with tempfile.TemporaryDirectory() as tempdir:
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+        )
+        certs_mount = scenario.Mount(
+            location="/support/TLS",
+            src=tempdir,
+        )
+        config_mount = scenario.Mount(
+            location="/free5gc/config",
+            src=tempdir,
+        )
+        container = scenario.Container(
+            name="ausf",
+            can_connect=True,
+            mounts={"config": config_mount, "certs": certs_mount},
+            layers={"ausf": Layer({"services": {"ausf": {}}})},
+            service_status={"ausf": ServiceStatus.ACTIVE},
+        )
+        interface_tester.configure(
+            charm_type=AUSFOperatorCharm,
+            state_template=scenario.State(
+                leader=True,
+                relations=[certificates_relation],
+                containers=[container],
+            ),
+        )
+        yield interface_tester

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -11,10 +11,6 @@ from charm import AUSFOperatorCharm
 @pytest.fixture
 def interface_tester(interface_tester: InterfaceTester):
     with tempfile.TemporaryDirectory() as tempdir:
-        certificates_relation = scenario.Relation(
-            endpoint="certificates",
-            interface="tls-certificates",
-        )
         certs_mount = scenario.Mount(
             location="/support/TLS",
             src=tempdir,
@@ -34,7 +30,6 @@ def interface_tester(interface_tester: InterfaceTester):
             charm_type=AUSFOperatorCharm,
             state_template=scenario.State(
                 leader=True,
-                relations=[certificates_relation],
                 containers=[container],
             ),
         )

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,10 @@ envlist = lint, static, unit
 
 [vars]
 src_path = {toxinidir}/src/
+interface_test_path = {toxinidir}/tests/interface/
 unit_test_path = {toxinidir}/tests/unit/
 integration_test_path = {toxinidir}/tests/integration/
-all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
+all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path} {[vars]interface_test_path}
 
 [testenv]
 setenv =


### PR DESCRIPTION
# Description

`sdcore-config` interface tests in https://github.com/canonical/charm-relation-interfaces are failing.
This PR adds a fixture of the AUSF operator that will be used during `sdcore-config` provider tests
It also add the `jinja2` dependency missing

https://github.com/canonical/charm-relation-interfaces/actions/runs/10444868384/job/28919962915
https://juju.is/docs/sdk/write-interface-tests

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library