### PR TITLE
chore: use built-in testing from ops

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -6,4 +6,3 @@ pytest
 pytest-asyncio>=v0.21.2  # https://github.com/pytest-dev/pytest/issues/12269
 pytest-operator
 ruff
-ops-scenario

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,25 +12,29 @@ cachetools==5.5.0
     # via google-auth
 certifi==2024.8.30
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.17.1
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 codespell==2.3.0
     # via -r test-requirements.in
-coverage[toml]==7.6.1
+coverage[toml]==7.6.2
     # via -r test-requirements.in
 cryptography==43.0.1
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
-durationpy==0.7
+durationpy==0.9
     # via kubernetes
 executing==2.1.0
     # via stack-data
@@ -39,17 +43,23 @@ google-auth==2.35.0
 hvac==2.3.0
     # via juju
 idna==3.10
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.27.0
+ipython==8.28.0
     # via ipdb
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.5.2.0
     # via
     #   -r test-requirements.in
@@ -59,7 +69,9 @@ kubernetes==31.0.0
 macaroonbakery==1.3.4
     # via juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.7
     # via ipython
 mypy-extensions==1.0.0
@@ -70,12 +82,9 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.17.0
-    # via ops-scenario
-ops-scenario==7.0.5
-    # via -r test-requirements.in
 packaging==24.1
     # via
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.5.0
@@ -85,7 +94,9 @@ parso==0.8.4
 pexpect==4.9.0
     # via ipython
 pluggy==1.5.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.48
     # via ipython
 protobuf==5.28.2
@@ -102,7 +113,9 @@ pyasn1==0.6.1
 pyasn1-modules==0.4.1
     # via google-auth
 pycparser==2.22
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.18.0
     # via ipython
 pymacaroons==0.13.0
@@ -116,10 +129,11 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pyright==1.1.383
+pyright==1.1.384
     # via -r test-requirements.in
 pytest==8.3.3
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -127,7 +141,7 @@ pytest-asyncio==0.21.2
     # via
     #   -r test-requirements.in
     #   pytest-operator
-pytest-operator==0.37.0
+pytest-operator==0.38.0
     # via -r test-requirements.in
 python-dateutil==2.9.0.post0
     # via kubernetes
@@ -135,10 +149,9 @@ pytz==2024.2
     # via pyrfc3339
 pyyaml==6.0.2
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
-    #   ops
-    #   ops-scenario
     #   pytest-operator
 requests==2.32.3
     # via
@@ -150,7 +163,7 @@ requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
-ruff==0.6.8
+ruff==0.6.9
     # via -r test-requirements.in
 six==1.16.0
     # via
@@ -169,6 +182,7 @@ traitlets==5.14.3
     #   matplotlib-inline
 typing-extensions==4.12.2
     # via
+    #   -c requirements.txt
     #   pyright
     #   typing-inspect
 typing-inspect==0.9.0
@@ -181,7 +195,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.8.0
     # via
+    #   -c requirements.txt
     #   kubernetes
-    #   ops
 websockets==13.1
     # via juju

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -4,7 +4,7 @@
 from unittest.mock import patch
 
 import pytest
-import scenario
+from ops import testing
 
 from charm import AUSFOperatorCharm
 
@@ -32,6 +32,6 @@ class AUSFUnitTestFixtures:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=AUSFOperatorCharm,
         )

--- a/tests/unit/test_charm_certificates_relation_broken.py
+++ b/tests/unit/test_charm_certificates_relation_broken.py
@@ -4,7 +4,7 @@
 import tempfile
 from pathlib import Path
 
-import scenario
+from ops import testing
 
 from tests.unit.certificates_helpers import (
     example_cert_and_key,
@@ -21,29 +21,29 @@ class TestCharmCertificateRelationBroken(AUSFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore-config",
                 remote_app_data={"webui_url": "whatever"},
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
@@ -57,7 +57,7 @@ class TestCharmCertificateRelationBroken(AUSFUnitTestFixtures):
                 f.write(str(private_key))
             with open(f"{tempdir}/ausf.pem", "w") as f:
                 f.write(str(provider_certificate.certificate))
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 relations={certificates_relation, nrf_relation, nms_relation},
                 leader=True,

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -3,8 +3,7 @@
 
 import tempfile
 
-import scenario
-from ops import ActiveStatus, BlockedStatus, WaitingStatus
+from ops import ActiveStatus, BlockedStatus, WaitingStatus, testing
 from ops.pebble import Layer, ServiceStatus
 
 from tests.unit.certificates_helpers import (
@@ -19,10 +18,10 @@ TEST_NRF_URL = "https://nrf-example.com:1234"
 
 class TestCharmCollectStatus(AUSFUnitTestFixtures):
     def test_given_unit_is_not_leader_when_collect_unit_status_then_status_is_blocked(self):
-        container = scenario.Container(
+        container = testing.Container(
             name=CONTAINER_NAME,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers={container},
             leader=False,
         )
@@ -34,11 +33,11 @@ class TestCharmCollectStatus(AUSFUnitTestFixtures):
     def test_given_unit_is_leader_but_container_is_not_ready_when_collect_unit_status_then_status_is_waiting(  # noqa: E501
         self,
     ):
-        container = scenario.Container(
+        container = testing.Container(
             name=CONTAINER_NAME,
             can_connect=False,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers={container},
             leader=True,
         )
@@ -50,11 +49,11 @@ class TestCharmCollectStatus(AUSFUnitTestFixtures):
     def test_given_unit_is_leader_and_container_is_ready_but_relations_are_not_created_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
         self,
     ):
-        container = scenario.Container(
+        container = testing.Container(
             name=CONTAINER_NAME,
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers={container},
             leader=True,
         )
@@ -68,15 +67,15 @@ class TestCharmCollectStatus(AUSFUnitTestFixtures):
     def test_given_unit_is_leader_and_container_is_ready_but_fiveg_nrf_relation_is_not_created_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name=CONTAINER_NAME,
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers={container},
             leader=True,
             relations={certificates_relation},
@@ -91,19 +90,19 @@ class TestCharmCollectStatus(AUSFUnitTestFixtures):
     def test_given_unit_is_leader_and_container_is_ready_but_sdcore_config_relation_is_not_created_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        fiveg_nrf_relation = scenario.Relation(
+        fiveg_nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg-nrf",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name=CONTAINER_NAME,
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers={container},
             leader=True,
             relations={certificates_relation, fiveg_nrf_relation},
@@ -116,19 +115,19 @@ class TestCharmCollectStatus(AUSFUnitTestFixtures):
     def test_given_unit_is_leader_and_container_is_ready_but_certificates_relation_is_not_created_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
         self,
     ):
-        fiveg_nrf_relation = scenario.Relation(
+        fiveg_nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg-nrf",
         )
-        nms_relation = scenario.Relation(
+        nms_relation = testing.Relation(
             endpoint="sdcore_config",
             interface="sdcore-config",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name=CONTAINER_NAME,
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers={container},
             leader=True,
             relations={fiveg_nrf_relation, nms_relation},
@@ -141,23 +140,23 @@ class TestCharmCollectStatus(AUSFUnitTestFixtures):
     def test_given_unit_is_leader_and_container_is_ready_and_relations_are_created_but_nrf_data_is_not_available_when_collect_unit_status_then_status_is_waiting(  # noqa: E501
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        fiveg_nrf_relation = scenario.Relation(
+        fiveg_nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg-nrf",
         )
-        nms_relation = scenario.Relation(
+        nms_relation = testing.Relation(
             endpoint="sdcore_config",
             interface="sdcore-config",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name=CONTAINER_NAME,
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers={container},
             leader=True,
             relations={certificates_relation, fiveg_nrf_relation, nms_relation},
@@ -170,24 +169,24 @@ class TestCharmCollectStatus(AUSFUnitTestFixtures):
     def test_given_unit_is_leader_and_container_is_ready_and_relations_are_created_but_webui_data_is_not_available_when_collect_unit_status_then_status_is_waiting(  # noqa: E501
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        fiveg_nrf_relation = scenario.Relation(
+        fiveg_nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg-nrf",
             remote_app_data={"url": TEST_NRF_URL},
         )
-        nms_relation = scenario.Relation(
+        nms_relation = testing.Relation(
             endpoint="sdcore_config",
             interface="sdcore-config",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name=CONTAINER_NAME,
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers={container},
             leader=True,
             relations={certificates_relation, fiveg_nrf_relation, nms_relation},
@@ -200,25 +199,25 @@ class TestCharmCollectStatus(AUSFUnitTestFixtures):
     def test_given_unit_is_leader_and_container_is_ready_and_relations_are_created_and_nrf_data_is_available_but_storage_is_not_ready_when_collect_unit_status_then_status_is_waiting(  # noqa: E501
         self,
     ):
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg-nrf",
             remote_app_data={"url": TEST_NRF_URL},
         )
-        nms_relation = scenario.Relation(
+        nms_relation = testing.Relation(
             endpoint="sdcore_config",
             interface="sdcore-config",
             remote_app_data={"webui_url": "whatever"},
         )
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name=CONTAINER_NAME,
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers={container},
             leader=True,
             relations={nrf_relation, nms_relation, certificates_relation},
@@ -232,34 +231,34 @@ class TestCharmCollectStatus(AUSFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore-config",
                 remote_app_data={"webui_url": "whatever"},
             )
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 leader=True,
                 relations={nrf_relation, nms_relation, certificates_relation},
@@ -276,34 +275,34 @@ class TestCharmCollectStatus(AUSFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore-config",
                 remote_app_data={"webui_url": "whatever"},
             )
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 leader=True,
                 relations={nrf_relation, nms_relation, certificates_relation},
@@ -322,34 +321,34 @@ class TestCharmCollectStatus(AUSFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore-config",
                 remote_app_data={"webui_url": "whatever"},
             )
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 leader=True,
                 relations={nrf_relation, nms_relation, certificates_relation},
@@ -368,36 +367,36 @@ class TestCharmCollectStatus(AUSFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore-config",
                 remote_app_data={"webui_url": "whatever"},
             )
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
                 layers={"ausf": Layer({"services": {"ausf": {}}})},
                 service_statuses={"ausf": ServiceStatus.ACTIVE},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 leader=True,
                 relations={nrf_relation, nms_relation, certificates_relation},
@@ -415,11 +414,11 @@ class TestCharmCollectStatus(AUSFUnitTestFixtures):
     def test_given_no_workload_version_file_when_collect_unit_status_then_workload_version_not_set(
         self,
     ):
-        container = scenario.Container(
+        container = testing.Container(
             name=CONTAINER_NAME,
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers={container},
             leader=True,
         )
@@ -433,16 +432,16 @@ class TestCharmCollectStatus(AUSFUnitTestFixtures):
     ):
         with tempfile.TemporaryDirectory() as tempdir:
             expected_version = "1.2.3"
-            workload_version_mount = scenario.Mount(
+            workload_version_mount = testing.Mount(
                 location="/etc",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"workload-version": workload_version_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 leader=True,
             )

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -5,7 +5,7 @@
 import tempfile
 from pathlib import Path
 
-import scenario
+from ops import testing
 from ops.pebble import Layer
 
 from tests.unit.certificates_helpers import (
@@ -24,34 +24,34 @@ class TestCharmConfigure(AUSFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore-config",
                 remote_app_data={"webui_url": "whatever"},
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 relations={certificates_relation, nrf_relation, nms_relation},
                 leader=True,
@@ -73,37 +73,37 @@ class TestCharmConfigure(AUSFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
             initial_certificate, initial_private_key = example_cert_and_key(
                 tls_relation_id=certificates_relation.id
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore-config",
                 remote_app_data={"webui_url": "whatever"},
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 relations={certificates_relation, nrf_relation, nms_relation},
                 leader=True,
@@ -129,34 +129,34 @@ class TestCharmConfigure(AUSFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore-config",
                 remote_app_data={"webui_url": "whatever"},
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 relations={certificates_relation, nrf_relation, nms_relation},
                 leader=True,
@@ -185,34 +185,34 @@ class TestCharmConfigure(AUSFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore-config",
                 remote_app_data={"webui_url": TEST_WEBUI_URL},
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 relations={certificates_relation, nrf_relation, nms_relation},
                 leader=True,
@@ -240,29 +240,29 @@ class TestCharmConfigure(AUSFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 relations={certificates_relation, nrf_relation},
                 leader=True,
@@ -291,34 +291,34 @@ class TestCharmConfigure(AUSFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore-config",
                 remote_app_data={"webui_url": TEST_WEBUI_URL},
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 relations={certificates_relation, nrf_relation, nms_relation},
                 leader=True,
@@ -366,34 +366,34 @@ class TestCharmConfigure(AUSFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore-config",
                 remote_app_data={"webui_url": TEST_WEBUI_URL},
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 relations={certificates_relation, nrf_relation, nms_relation},
                 leader=True,
@@ -412,34 +412,34 @@ class TestCharmConfigure(AUSFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore-config",
                 remote_app_data={"webui_url": TEST_WEBUI_URL},
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 relations={certificates_relation, nrf_relation, nms_relation},
                 leader=True,
@@ -462,29 +462,29 @@ class TestCharmConfigure(AUSFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 relations={certificates_relation, nrf_relation},
                 leader=True,
@@ -514,34 +514,34 @@ class TestCharmConfigure(AUSFUnitTestFixtures):
     ):
         expected_nrf_url = "https://new-nrf-url:1234"
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": expected_nrf_url},
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore-config",
                 remote_app_data={"webui_url": TEST_WEBUI_URL},
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 relations={certificates_relation, nrf_relation, nms_relation},
                 leader=True,
@@ -570,34 +570,34 @@ class TestCharmConfigure(AUSFUnitTestFixtures):
     ):
         expected_webui_url = "https://new-webui-url"
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg-nrf",
                 remote_app_data={"url": TEST_NRF_URL},
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore-config",
                 remote_app_data={"webui_url": expected_webui_url},
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name=CONTAINER_NAME,
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers={container},
                 relations={certificates_relation, nrf_relation, nms_relation},
                 leader=True,


### PR DESCRIPTION
# Description

Now that scenario testing is built into ops we don't need to import it as a separate dependency. Here we use `ops.testing` instead of scenario. Both have the same API.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library