### PR TITLE
fix: Fix MongoDB deployment in integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Charmed Operator for Aether SD-Core's Authentication Server Function (AUSF) co
 juju deploy sdcore-ausf-k8s --channel=1.5/edge
 juju deploy sdcore-nrf-k8s --channel=1.5/edge
 juju deploy sdcore-nms-k8s --channel=1.5/edge
-juju deploy mongodb-k8s --trust --channel=6/beta
+juju deploy mongodb-k8s --trust --channel=6/stable
 juju deploy self-signed-certificates
 juju integrate sdcore-nrf-k8s:database mongodb-k8s
 juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -18,7 +18,7 @@ METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 DB_APPLICATION_NAME = "mongodb-k8s"
-DB_APPLICATION_CHANNEL = "6/beta"
+DB_APPLICATION_CHANNEL = "6/stable"
 NRF_APPLICATION_NAME = "sdcore-nrf-k8s"
 NRF_APPLICATION_CHANNEL = "1.5/edge"
 NMS_APPLICATION_NAME = "sdcore-nms-k8s"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -153,6 +153,7 @@ async def _deploy_mongodb(ops_test: OpsTest):
         DB_APPLICATION_NAME,
         application_name=DB_APPLICATION_NAME,
         channel=DB_APPLICATION_CHANNEL,
+        trust=True,
     )
 
 


### PR DESCRIPTION
# Description

- Adds `trust=True` to MongoDB deployment
- Sets MongoDB channel to `6/stable`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library