### PR TITLE
fix: Use semantic commits in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,8 +4,7 @@
     "config:recommended",
     ":disableRateLimiting",
     ":noUnscheduledUpdates",
-    // Avoid conflicts with custom `commitMessagePrefix`
-    ":semanticCommitsDisabled"
+    ":semanticCommits"
   ],
   "automerge": true,
   "automergeStrategy": "squash",


### PR DESCRIPTION
# Description

Use semantic commits in Renovate.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library