### PR TITLE
fix: use ubuntu@24.04 in TF modules

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,7 @@ resource "juju_application" "ausf" {
     name     = "sdcore-ausf-k8s"
     channel  = var.channel
     revision = var.revision
+    base     = var.base
   }
 
   config      = var.config

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,6 +43,12 @@ variable "revision" {
   default     = null
 }
 
+variable "base" {
+  description = "The operating system on which to deploy"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "units" {
   description = "Number of units to deploy"
   type        = number

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -27,7 +27,7 @@ TLS_PROVIDER_NAME = "self-signed-certificates"
 TLS_PROVIDER_CHANNEL = "latest/stable"
 GRAFANA_AGENT_CHARM_NAME = "grafana-agent-k8s"
 GRAFANA_AGENT_CHARM_CHANNEL = "latest/stable"
-SDCORE_CHARMS_BASE = "ubuntu@24.04"
+SDCORE_CHARMS_SERIES = "noble"
 TIMEOUT = 15 * 60
 
 
@@ -152,7 +152,7 @@ async def _deploy_nrf(ops_test: OpsTest):
         NRF_APPLICATION_NAME,
         application_name=NRF_APPLICATION_NAME,
         channel=NRF_APPLICATION_CHANNEL,
-        base=SDCORE_CHARMS_BASE,
+        series=SDCORE_CHARMS_SERIES, # TODO: This should be replaced with base="ubuntu@24.04" once it's properly supported # noqa: E501
     )
     await ops_test.model.integrate(relation1=DB_APPLICATION_NAME, relation2=NRF_APPLICATION_NAME)
     await ops_test.model.integrate(relation1=NRF_APPLICATION_NAME, relation2=TLS_PROVIDER_NAME)
@@ -168,7 +168,7 @@ async def _deploy_nms(ops_test: OpsTest):
         NMS_APPLICATION_NAME,
         application_name=NMS_APPLICATION_NAME,
         channel=NMS_APPLICATION_CHANNEL,
-        base=SDCORE_CHARMS_BASE,
+        series=SDCORE_CHARMS_SERIES, # TODO: This should be replaced with base="ubuntu@24.04" once it's properly supported # noqa: E501
     )
     await ops_test.model.integrate(
         relation1=f"{NMS_APPLICATION_NAME}:common_database", relation2=DB_APPLICATION_NAME

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -152,7 +152,7 @@ async def _deploy_nrf(ops_test: OpsTest):
         NRF_APPLICATION_NAME,
         application_name=NRF_APPLICATION_NAME,
         channel=NRF_APPLICATION_CHANNEL,
-        series=SDCORE_CHARMS_SERIES, # TODO: This should be replaced with base="ubuntu@24.04" once it's properly supported # noqa: E501
+        series=SDCORE_CHARMS_SERIES,  # TODO: This should be replaced with base="ubuntu@24.04" once it's properly supported # noqa: E501
     )
     await ops_test.model.integrate(relation1=DB_APPLICATION_NAME, relation2=NRF_APPLICATION_NAME)
     await ops_test.model.integrate(relation1=NRF_APPLICATION_NAME, relation2=TLS_PROVIDER_NAME)
@@ -168,7 +168,7 @@ async def _deploy_nms(ops_test: OpsTest):
         NMS_APPLICATION_NAME,
         application_name=NMS_APPLICATION_NAME,
         channel=NMS_APPLICATION_CHANNEL,
-        series=SDCORE_CHARMS_SERIES, # TODO: This should be replaced with base="ubuntu@24.04" once it's properly supported # noqa: E501
+        series=SDCORE_CHARMS_SERIES,  # TODO: This should be replaced with base="ubuntu@24.04" once it's properly supported # noqa: E501
     )
     await ops_test.model.integrate(
         relation1=f"{NMS_APPLICATION_NAME}:common_database", relation2=DB_APPLICATION_NAME

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -27,6 +27,7 @@ TLS_PROVIDER_NAME = "self-signed-certificates"
 TLS_PROVIDER_CHANNEL = "latest/stable"
 GRAFANA_AGENT_CHARM_NAME = "grafana-agent-k8s"
 GRAFANA_AGENT_CHARM_CHANNEL = "latest/stable"
+SDCORE_CHARMS_BASE = "ubuntu@24.04"
 TIMEOUT = 15 * 60
 
 
@@ -151,6 +152,7 @@ async def _deploy_nrf(ops_test: OpsTest):
         NRF_APPLICATION_NAME,
         application_name=NRF_APPLICATION_NAME,
         channel=NRF_APPLICATION_CHANNEL,
+        base=SDCORE_CHARMS_BASE,
     )
     await ops_test.model.integrate(relation1=DB_APPLICATION_NAME, relation2=NRF_APPLICATION_NAME)
     await ops_test.model.integrate(relation1=NRF_APPLICATION_NAME, relation2=TLS_PROVIDER_NAME)
@@ -166,6 +168,7 @@ async def _deploy_nms(ops_test: OpsTest):
         NMS_APPLICATION_NAME,
         application_name=NMS_APPLICATION_NAME,
         channel=NMS_APPLICATION_CHANNEL,
+        base=SDCORE_CHARMS_BASE,
     )
     await ops_test.model.integrate(
         relation1=f"{NMS_APPLICATION_NAME}:common_database", relation2=DB_APPLICATION_NAME


### PR DESCRIPTION
# Description

By default, Juju fetches charms with base matching the host OS. It means that when running Jammy, Juju won’t use latest charms, because we’ve changed the base to Noble.

Adding an optional (as per CC006) config param base will allow using Noble (base should be set to ubuntu@24.04) regardless of the host OS.

Enforcing Noble on a Juju model configuration level is not an option, because it breaks COS integration (COS charms are not available in ubuntu@24.04).

## ATTENTION
As a workaround to this issue https://github.com/juju/python-libjuju/issues/1240 we use, series instead of base in the integration tests.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library